### PR TITLE
Add batch trading controls

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -30,6 +30,7 @@ class GeneralSettings:
     chart_update_interval_ms: int = 500
     min_bars_for_trading: int = 50
     risk_percentage: float = 1.0
+    batch_profit_target: float = 10.0
     # Add other general app settings here if any
 
 @dataclass
@@ -79,7 +80,8 @@ class Settings:
             default_symbol=general_cfg.get("default_symbol", "EUR/USD"),
             chart_update_interval_ms=general_cfg.get("chart_update_interval_ms", 500),
             min_bars_for_trading=general_cfg.get("min_bars_for_trading", 50),
-            risk_percentage=general_cfg.get("risk_percentage", 1.0)
+            risk_percentage=general_cfg.get("risk_percentage", 1.0),
+            batch_profit_target=general_cfg.get("batch_profit_target", 10.0)
         )
 
         return Settings(openapi=openapi_settings, general=general_settings)
@@ -111,6 +113,7 @@ class Settings:
                 "chart_update_interval_ms": self.general.chart_update_interval_ms,
                 "min_bars_for_trading": self.general.min_bars_for_trading,
                 "risk_percentage": self.general.risk_percentage,
+                "batch_profit_target": self.general.batch_profit_target,
             }
         }
         with open(path, 'w') as f:

--- a/trading.py
+++ b/trading.py
@@ -1576,6 +1576,17 @@ class Trader:
             counts[tf_str] = len(df_history)
         return counts
 
+    def close_all_positions(self) -> None:
+        """Attempt to close all open positions on the connected account."""
+        if not USE_OPENAPI_LIB:
+            print("Mock close_all_positions called.")
+            return
+        # TODO: Implement logic using ProtoOAClosePositionReq messages
+        try:
+            print("close_all_positions not fully implemented in this example")
+        except Exception as e:
+            print(f"Error closing positions: {e}")
+
     def place_market_order(
         self,
         symbol_name: str,


### PR DESCRIPTION
## Summary
- introduce `batch_profit_target` setting
- track batch trading in GUI and stop when profit target hit
- add basic UI field for batch profit target
- add stub for closing all positions in Trader

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688227c9b7a8832681e769712706d1f0

## Summary by Sourcery

Introduce batch trading controls by adding a configurable batch profit target and integrating it into the scalping workflow to automatically halt trading and close positions when the profit threshold is met.

New Features:
- Add batch_profit_target setting with load/save support in configuration
- Expose batch profit target input field in the GUI
- Track batch trade count and starting equity in the scalping loop
- Automatically stop scalping and invoke close_all_positions when batch profit target is reached
- Provide a stub for close_all_positions in the Trader interface

Enhancements:
- Adjust GUI layout rows to accommodate the new batch profit target field